### PR TITLE
Add Bluesky portfolio entry type

### DIFF
--- a/__tests__/PortfolioEntry.test.jsx
+++ b/__tests__/PortfolioEntry.test.jsx
@@ -5,6 +5,7 @@ import PortfolioEntry, {
   LinkedInEntry,
   EmailEntry,
   BitbucketEntry,
+  BlueskyEntry,
   StackOverflowEntry,
   StackExchangeEntry,
 } from '../components/PortfolioEntry'
@@ -16,6 +17,7 @@ const wrappers = {
   linkedin: [LinkedInEntry, 'linkedin-in'],
   email: [EmailEntry, 'at'],
   bitbucket: [BitbucketEntry, 'bitbucket'],
+  bluesky: [BlueskyEntry, 'bluesky'],
   'stack-overflow': [StackOverflowEntry, 'stack-overflow'],
   'stack-exchange': [StackExchangeEntry, 'stack-exchange'],
 }

--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -20,6 +20,7 @@ describe('Home page', () => {
     const entries = [
       { url: 'https://github.com/u', title: 'GitHub', type: 'github' },
       { url: 'https://twitter.com/u', title: 'Twitter', type: 'twitter' },
+      { url: 'https://bsky.app/profile/u.bsky.social', title: 'Bluesky', type: 'bluesky' },
       { url: 'https://www.linkedin.com/in/u', title: 'LinkedIn', type: 'linkedin' },
       { url: 'mailto:u@example.com', title: 'Email u@example.com', type: 'email', target: '_self' },
       { url: 'https://bitbucket.org/u', title: 'Bitbucket', type: 'bitbucket' },

--- a/components/PortfolioEntries.jsx
+++ b/components/PortfolioEntries.jsx
@@ -5,6 +5,7 @@ import PortfolioEntry, {
   LinkedInEntry,
   EmailEntry,
   BitbucketEntry,
+  BlueskyEntry,
   StackOverflowEntry,
   StackExchangeEntry,
 } from './PortfolioEntry'
@@ -15,6 +16,7 @@ const map = {
   linkedin: LinkedInEntry,
   email: EmailEntry,
   bitbucket: BitbucketEntry,
+  bluesky: BlueskyEntry,
   'stack-overflow': StackOverflowEntry,
   'stack-exchange': StackExchangeEntry,
 }

--- a/components/PortfolioEntry.jsx
+++ b/components/PortfolioEntry.jsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faGithub,
   faTwitter,
+  faBluesky,
   faLinkedinIn,
   faBitbucket,
   faStackOverflow,
@@ -32,3 +33,4 @@ export const EmailEntry = (props) => <PortfolioEntry {...props} icon={faAt} type
 export const BitbucketEntry = (props) => <PortfolioEntry {...props} icon={faBitbucket} type="bitbucket" />
 export const StackOverflowEntry = (props) => <PortfolioEntry {...props} icon={faStackOverflow} type="stack-overflow" />
 export const StackExchangeEntry = (props) => <PortfolioEntry {...props} icon={faStackExchange} type="stack-exchange" />
+export const BlueskyEntry = (props) => <PortfolioEntry {...props} icon={faBluesky} type="bluesky" />

--- a/lib/getPortfolioProps.js
+++ b/lib/getPortfolioProps.js
@@ -67,6 +67,11 @@ export default function getPortfolioProps() {
       title: 'Twitter',
       type: 'twitter',
     }),
+    bluesky: (cfg) => ({
+      url: cfg.handle ? `https://bsky.app/profile/${cfg.handle}` : null,
+      title: 'Bluesky',
+      type: 'bluesky',
+    }),
     linkedIn: (cfg) => ({
       url: cfg.username ? `https://www.linkedin.com/in/${cfg.username}` : null,
       title: 'LinkedIn',

--- a/portfolio.default.json
+++ b/portfolio.default.json
@@ -37,25 +37,29 @@
             "handle": "twitter",
             "order": 1
         },
+        "bluesky": {
+            "handle": "example.bsky.social",
+            "order": 2
+        },
         "linkedIn": {
             "username": "jeffweiner08",
-            "order": 2
+            "order": 3
         },
         "email": {
             "address": "email@example.com",
-            "order": 3
+            "order": 4
         },
         "bitbucket": {
             "username": "example",
-            "order": 4
+            "order": 5
         },
         "stackOverflow": {
             "id": "1",
-            "order": 5
+            "order": 6
         },
         "stackExchange": {
             "id": "1",
-            "order": 6
+            "order": 7
         }
     }
 }


### PR DESCRIPTION
## Summary
- support Bluesky profiles
- include Bluesky example in default portfolio configuration
- test Bluesky PortfolioEntry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fcea32a50833285ce42fbd0f673eb