### PR TITLE
Add portfolio.json documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,56 @@ defaults to the value in `DEFAULT_GOOGLE_FONTS_URL` inside `pages/index.js`.
 2. Add each font to your selection then open the **Get embed code** panel.
 3. Copy the `href` attribute from the `<link>` tag and place it in
    `style.fonts.googleFontsUrl`.
+
+## `portfolio.json` Reference
+
+The file `portfolio.json` controls what content appears on your portfolio site. Below is an explanation of every supported field and where to obtain its value.
+
+### Basic Fields
+
+* `title` – The main heading displayed on the page.
+* `pageTitle` – (optional) Title shown in the browser tab. Defaults to `title` when omitted.
+* `description` – Markdown text shown below the heading.
+* `googleAnalyticsID` – (optional) Measurement ID for Google Analytics. Create a property at [analytics.google.com](https://analytics.google.com), open the Web stream for your site and copy the *Measurement ID* (for example `G-XXXXXXX`).
+* `gravatarEmail` – (optional) Email address associated with your [Gravatar](https://gravatar.com) account. The site hashes this email to fetch the avatar image.
+
+### Favicon and Header Picture
+
+* `favicon.linkUrl` – URL to an image used as the browser favicon.
+* `favicon.useGravatar` – Set to `true` to use the avatar from `gravatarEmail` instead of `linkUrl`.
+* `headerPicture.linkUrl` – URL of the picture displayed in the page header.
+* `headerPicture.useGravatar` – Set to `true` to display your Gravatar.
+* `headerPicture.pictureText` – Alternate text for the header picture.
+
+### Styling
+
+The optional `style.colors` and `style.fonts` objects override the default colours and fonts as shown above. The `googleFontsUrl` value should be copied from the `href` attribute of the embed link on [Google Fonts](https://fonts.google.com).
+
+### Portfolio Links
+
+`portfolio` contains entries for the icons displayed on the page. Each entry accepts an optional `order` property to control its position. Supported entries are:
+
+* `github.username` – GitHub user name.
+* `twitter.handle` – Twitter handle without the `@`.
+* `bluesky.handle` – Bluesky handle.
+* `linkedIn.username` – LinkedIn profile name.
+* `email.address` – Email address for the mail link.
+* `bitbucket.username` – Bitbucket user name.
+* `stackOverflow.id` – Numeric user ID from your Stack Overflow profile URL.
+* `stackExchange.id` – Numeric user ID from your Stack Exchange profile URL.
+
+### Minimal Example
+
+`portfolio.minimal.json` contains the smallest possible configuration:
+
+```json
+{
+  "title": "Developer Name",
+  "description": "A short description about me.",
+  "portfolio": {
+    "github": { "username": "github" }
+  }
+}
+```
+
+Copy this file to `portfolio.json` and update the values to get started quickly.

--- a/portfolio.minimal.json
+++ b/portfolio.minimal.json
@@ -1,0 +1,7 @@
+{
+  "title": "Developer Name",
+  "description": "A short description about me.",
+  "portfolio": {
+    "github": { "username": "github" }
+  }
+}


### PR DESCRIPTION
## Summary
- document all config fields of `portfolio.json`
- add instructions for obtaining Google Analytics IDs, Gravatar, and Stack Overflow IDs
- provide `portfolio.minimal.json` example

References TODO item *Better explanation and examples of available configuration options*.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fd2472eb88332aa816cfd478d6743